### PR TITLE
Transition to Skills/CLI paradigm

### DIFF
--- a/.claude/commands/espn-analyze.md
+++ b/.claude/commands/espn-analyze.md
@@ -1,0 +1,71 @@
+# ESPN Fantasy Football Analysis
+
+Higher-order analysis that combines multiple data sources: trade advice, waiver
+recommendations, playoff projections, and head-to-head comparisons.
+
+## Usage
+
+The user asks a strategic fantasy football question. Use this skill to chain
+multiple CLI calls together and synthesize the results into actionable advice.
+
+Always ask for **League ID** first. Collect other parameters as needed.
+
+## Available data commands
+
+```bash
+# League overview & team list (gives you team IDs)
+uv run python -m mcp_espn_ff.cli league-info --league-id <ID>
+
+# Full standings
+uv run python -m mcp_espn_ff.cli standings --league-id <ID>
+
+# One team's roster (repeat for each team you want to compare)
+uv run python -m mcp_espn_ff.cli roster --league-id <ID> --team-id <N>
+
+# One team's season stats
+uv run python -m mcp_espn_ff.cli team-info --league-id <ID> --team-id <N>
+
+# Player lookup
+uv run python -m mcp_espn_ff.cli player --league-id <ID> --name "<NAME>"
+
+# Weekly matchups
+uv run python -m mcp_espn_ff.cli matchups --league-id <ID> [--week <W>]
+```
+
+All commands accept `--year <YEAR>` (defaults to current season).
+
+## Analysis workflows
+
+### Trade evaluation
+1. Fetch roster for both teams involved (`roster --team-id`).
+2. Fetch player stats for key players being traded (`player --name`).
+3. Assess: positional needs, points contribution, injury risk, schedule strength.
+4. Give a clear verdict: who wins the trade and why.
+
+### Waiver wire recommendations
+1. Fetch the requesting team's roster.
+2. Identify the weakest position by comparing actual vs. projected points.
+3. Suggest which player to drop and why.
+4. (If you have waiver data from the ESPN API, list top available players at that position.)
+
+### Playoff projection
+1. Fetch standings (wins, points for).
+2. Fetch remaining matchups.
+3. Estimate likely outcomes and who makes the playoffs.
+
+### Head-to-head comparison
+1. Fetch both teams' rosters.
+2. Compare position-by-position: QB, RB, WR, TE, K, DEF.
+3. Project a winner based on projected points and injury status.
+
+### Season recap
+1. Fetch standings.
+2. Fetch team-info for all teams (loop over team IDs 1..N).
+3. Summarize: most transactions, highest scorer, biggest overachiever vs. projections.
+
+## Output style
+
+- Lead with a clear, direct answer or recommendation.
+- Support it with 2–3 specific data points from the CLI output.
+- Keep it concise — fantasy managers want actionable insight, not raw numbers.
+- If the output contains `"error": "private_league"`, tell the user to run `/espn-auth` first.

--- a/.claude/commands/espn-auth.md
+++ b/.claude/commands/espn-auth.md
@@ -1,0 +1,26 @@
+# ESPN Authentication
+
+Opens a browser so you can log in to ESPN and saves the credentials to `.env`.
+
+## When to use this skill
+
+Run this when ESPN API calls return a "private league" or 401 error, or when no
+credentials exist in the environment.
+
+## Steps
+
+1. Tell the user what's about to happen:
+   > "I'll open a Chromium browser window. Please log in to your ESPN account there. I'll detect the cookies automatically."
+
+2. Run:
+   ```bash
+   cd $PROJECT_ROOT && uv run python -m mcp_espn_ff.cli authenticate
+   ```
+
+3. The command will block until the user logs in (up to 3 minutes). If it times out, let the user know and suggest they retry.
+
+4. On success the output contains `ESPN_S2` and `SWID` values. Tell the user:
+   - Credentials are saved to `.env` automatically.
+   - They can also copy the values into their environment or CI secrets if needed.
+
+5. If there is an error, show it to the user and suggest running `python -m playwright install chromium` if Playwright is not installed.

--- a/.claude/commands/espn-league.md
+++ b/.claude/commands/espn-league.md
@@ -1,0 +1,41 @@
+# ESPN League Overview
+
+Retrieve league info, standings, or weekly matchups from an ESPN Fantasy Football league.
+
+## Usage
+
+When the user asks about their league, standings, or matchups, ask for:
+- **League ID** (required) — found in the ESPN URL: `fantasy.espn.com/football/league?leagueId=XXXXX`
+- **Year** (optional, defaults to current season)
+- **Week** (for matchups only, optional — defaults to current week)
+
+## Commands
+
+### League info (name, teams, scoring type, current week)
+```bash
+cd $PROJECT_ROOT && uv run python -m mcp_espn_ff.cli league-info --league-id <LEAGUE_ID> [--year <YEAR>]
+```
+
+### Standings (ranked by wins, then points)
+```bash
+cd $PROJECT_ROOT && uv run python -m mcp_espn_ff.cli standings --league-id <LEAGUE_ID> [--year <YEAR>]
+```
+
+### Matchups for a week
+```bash
+cd $PROJECT_ROOT && uv run python -m mcp_espn_ff.cli matchups --league-id <LEAGUE_ID> [--week <WEEK>] [--year <YEAR>]
+```
+
+## Interpreting results
+
+- All output is JSON. Parse and summarize it for the user in plain language.
+- For standings: present as a numbered table with W-L record and points scored.
+- For matchups: show home vs. away with scores and who won.
+- If the output contains `"error": "private_league"`, tell the user to run `/espn-auth` first.
+
+## Example follow-up analysis
+
+After fetching data, offer to:
+- Identify the top scorer or biggest upset of the week (matchups).
+- Highlight any teams on win/loss streaks (standings).
+- Compare two specific teams head-to-head by fetching both rosters with `/espn-roster`.

--- a/.claude/commands/espn-roster.md
+++ b/.claude/commands/espn-roster.md
@@ -1,0 +1,48 @@
+# ESPN Roster & Player Stats
+
+Look up a team's full roster or search for a specific player's stats.
+
+## Usage
+
+Ask the user for:
+- **League ID** (required)
+- **Team ID** (required for roster — numbered 1..N, visible in league standings output)
+- **Player name** (for player lookup — partial/fuzzy match is supported)
+- **Year** (optional, defaults to current season)
+
+Tip: If the user doesn't know their team ID, run the standings command first
+(`/espn-league`) — teams are listed in rank order and their position in that list
+is their team ID.
+
+## Commands
+
+### Full team roster
+```bash
+cd $PROJECT_ROOT && uv run python -m mcp_espn_ff.cli roster --league-id <LEAGUE_ID> --team-id <TEAM_ID> [--year <YEAR>]
+```
+
+### Team season stats (W-L, points for/against, trades, playoff %)
+```bash
+cd $PROJECT_ROOT && uv run python -m mcp_espn_ff.cli team-info --league-id <LEAGUE_ID> --team-id <TEAM_ID> [--year <YEAR>]
+```
+
+### Individual player stats (fuzzy name search across all rosters)
+```bash
+cd $PROJECT_ROOT && uv run python -m mcp_espn_ff.cli player --league-id <LEAGUE_ID> --name "<PLAYER_NAME>" [--year <YEAR>]
+```
+
+## Interpreting results
+
+- **Roster**: list each player with position, pro team, actual points, and projected points.
+  Flag any injured players.
+- **Team info**: summarize wins/losses, scoring pace, activity (acquisitions, drops, trades),
+  and playoff outlook.
+- **Player**: show points vs. projected and injury status. Note if they are significantly
+  over/under-performing projections.
+- If the output contains `"error": "private_league"`, tell the user to run `/espn-auth` first.
+
+## Example follow-up analysis
+
+- "Who is the weakest position on this roster?" — compare projected vs. actual by position.
+- "Should I drop this player?" — look at injury status, points trend, and available alternatives.
+- "Compare my roster to my opponent's" — fetch both rosters and compare position-by-position.

--- a/README.md
+++ b/README.md
@@ -1,68 +1,70 @@
-# ESPN Fantasy Football MCP Server
+# ESPN Fantasy Football — Claude Code Skills
 
-## Overview
+Query and analyze your ESPN Fantasy Football league directly from Claude Code using slash commands.
 
-This MCP (Model Context Protocol) server allows LLMs to interact with the ESPN Fantasy Football API. It provides tools for accessing league data, team rosters, player statistics, and more through a standardized interface. It can work with both public and private ESPN Leagues.
+This project is forked from [KBThree13/mcp_espn_ff](https://github.com/KBThree13/mcp_espn_ff).
 
-This project is forked from [KBThree13/mcp_espn_ff](https://github.com/KBThree13/mcp_espn_ff). It expands on that project by adding compatibilty with other LLM clients, such as Perplexity, and adds an authentication tool so that users can easily find their authentication tokens from ESPN.
+## Features
 
-## Features (MCP Tools)
+| Skill | Command | What it does |
+|-------|---------|--------------|
+| Authentication | `/espn-auth` | Opens a browser to log in to ESPN and saves credentials to `.env` |
+| League overview | `/espn-league` | League info, standings, weekly matchups |
+| Roster & players | `/espn-roster` | Team rosters, individual player stats, team season info |
+| Analysis | `/espn-analyze` | Trade advice, waiver picks, playoff projections, head-to-head comparisons |
 
-- **Authentication**: Open a browser for user to sign-in so that they can automatically find authentication tokens. Tokens can be stored in the LLM client or in a .env file.
-- **League Info**: Get basic information about fantasy football leagues
-- **Team Rosters**: View current team rosters and player details
-- **Player Stats**: Find and display stats for specific players
-- **League Standings**: View current team rankings and performance metrics
-- **Matchup Information**: Get details about weekly matchups
+## Prerequisites
+
+- Python 3.12+
+- [`uv`](https://docs.astral.sh/uv/) package manager
+- Claude Code
 
 ## Installation
 
-### Prerequisites
+```bash
+git clone https://github.com/morgankeys/mcp_espn_ff
+cd mcp_espn_ff
+uv sync
+python -m playwright install chromium
+```
 
-- Python 3.10 or higher
-- `uv` package manager
-  - espn-api >= 0.44.1
-  - mcp[cli] >=1.5.0
-  - playwright >=1.45.0
-  - python-dotenv >=1.0.1
+## Authentication
 
+ESPN credentials (`ESPN_S2` and `SWID`) are required for private leagues.
 
-## Usage with LLM Clients
+**Option A — browser login (recommended):**
+Run `/espn-auth` in Claude Code. A Chromium window will open; log in and credentials
+are saved to `.env` automatically.
 
-### Perplexity
+**Option B — manual:**
+Create a `.env` file in the project root:
+```
+ESPN_S2=<your value>
+SWID=<your value>
+```
+You can find these values in your browser cookies after logging in to ESPN.
 
-1. Add MCP_ESPN_FF as a [connector in Perplexity](https://www.perplexity.ai/search/how-do-i-add-a-connector-the-p-O2JTAQUFRiKI68X_4N43ww).
+Public leagues work without any credentials.
 
-2. Add the following environment variables as part of the connector (case sensitive):
-  - "espn_s2"
-  - "SWID"
+## CLI reference
 
-  If you already know these tokens, you can add them or ask the connector to authencticate and print the tokens. (Recommend you delete the chat later).
+The skills use an underlying CLI that you can also call directly:
 
+```bash
+uv run python -m mcp_espn_ff.cli league-info --league-id <ID>
+uv run python -m mcp_espn_ff.cli standings   --league-id <ID> [--year <YEAR>]
+uv run python -m mcp_espn_ff.cli matchups    --league-id <ID> [--week <WEEK>]
+uv run python -m mcp_espn_ff.cli roster      --league-id <ID> --team-id <N>
+uv run python -m mcp_espn_ff.cli team-info   --league-id <ID> --team-id <N>
+uv run python -m mcp_espn_ff.cli player      --league-id <ID> --name "<NAME>"
+uv run python -m mcp_espn_ff.cli authenticate
+```
 
-### Claude Desktop
+All commands output JSON. Add `--help` to any subcommand for details.
 
-1. Update the Claude Desktop config:
-- MacOS: `~/Library/Application Support/Claude/claude_desktop_config.json`
-- Include reference to the MCP server
-  ```json
-  {
-    "args" : [
-      "--directory",
-      "/Users/morgankeys/gits/mcp_espn_ff",
-      "run",
-      "server.py"
-    ],
-    "command" : "uv",
-    "env" : {
-      "SWID" : "<value>",
-      "espn_s2" : "<value>"
-    }
-  }
-  ```
-2. Restart Claude Desktop
-
+Your **League ID** is in the ESPN URL: `fantasy.espn.com/football/league?leagueId=XXXXX`
 
 ## Acknowledgements
-- [KBThree13/mcp_espn_ff](https://github.com/KBThree13/mcp_espn_ff) - The repo this project is forked from
-- [cwendt94/espn-api](https://github.com/cwendt94/espn-api) - Nifty python wrapper around the ESPN Fantasy API
+
+- [KBThree13/mcp_espn_ff](https://github.com/KBThree13/mcp_espn_ff) — original MCP server this project is forked from
+- [cwendt94/espn-api](https://github.com/cwendt94/espn-api) — Python wrapper for the ESPN Fantasy API

--- a/mcp_espn_ff/cli.py
+++ b/mcp_espn_ff/cli.py
@@ -1,0 +1,306 @@
+"""
+ESPN Fantasy Football CLI — used by Claude Code skills.
+
+Each subcommand mirrors one of the original MCP tools, but runs as a
+standalone process that prints human-readable (or JSON) output to stdout.
+
+Usage examples:
+    python -m mcp_espn_ff.cli league-info --league-id 12345
+    python -m mcp_espn_ff.cli standings   --league-id 12345 --year 2024
+    python -m mcp_espn_ff.cli roster      --league-id 12345 --team-id 3
+    python -m mcp_espn_ff.cli team-info   --league-id 12345 --team-id 3
+    python -m mcp_espn_ff.cli player      --league-id 12345 --name "Mahomes"
+    python -m mcp_espn_ff.cli matchups    --league-id 12345 --week 5
+    python -m mcp_espn_ff.cli authenticate
+"""
+
+import argparse
+import asyncio
+import datetime
+import json
+import sys
+
+from .espn_service import LeagueService, ensure_authenticated
+
+CURRENT_YEAR = datetime.datetime.now().year
+if datetime.datetime.now().month < 7:
+    CURRENT_YEAR -= 1
+
+_league_service = LeagueService()
+
+
+def _out(data) -> None:
+    """Print dict/list as pretty JSON, or plain string as-is."""
+    if isinstance(data, (dict, list)):
+        print(json.dumps(data, indent=2, default=str))
+    else:
+        print(data)
+
+
+def _private_league_hint(err: Exception) -> bool:
+    return "401" in str(err) or "Private" in str(err)
+
+
+# ---------------------------------------------------------------------------
+# Subcommand implementations
+# ---------------------------------------------------------------------------
+
+async def cmd_authenticate(_args) -> int:
+    try:
+        espn_s2, swid, _state = await ensure_authenticated(persist_mode="dot_env")
+        _out({
+            "status": "authenticated",
+            "ESPN_S2": espn_s2,
+            "SWID": swid,
+            "note": "Credentials saved to .env and active for this session.",
+        })
+        return 0
+    except Exception as e:
+        _out({"error": str(e)})
+        return 1
+
+
+async def cmd_league_info(args) -> int:
+    try:
+        league = await _league_service.get_league(args.league_id, args.year)
+        _out({
+            "name": league.settings.name,
+            "year": league.year,
+            "current_week": league.current_week,
+            "nfl_week": league.nfl_week,
+            "team_count": len(league.teams),
+            "teams": [t.team_name for t in league.teams],
+            "scoring_type": league.settings.scoring_type,
+        })
+        return 0
+    except Exception as e:
+        if _private_league_hint(e):
+            _out({"error": "private_league", "hint": "Run: python -m mcp_espn_ff.cli authenticate"})
+        else:
+            _out({"error": str(e)})
+        return 1
+
+
+async def cmd_standings(args) -> int:
+    try:
+        league = await _league_service.get_league(args.league_id, args.year)
+        sorted_teams = sorted(league.teams, key=lambda t: (t.wins, t.points_for), reverse=True)
+        _out([
+            {
+                "rank": i + 1,
+                "team_name": t.team_name,
+                "owner": t.owners,
+                "wins": t.wins,
+                "losses": t.losses,
+                "points_for": t.points_for,
+                "points_against": t.points_against,
+            }
+            for i, t in enumerate(sorted_teams)
+        ])
+        return 0
+    except Exception as e:
+        if _private_league_hint(e):
+            _out({"error": "private_league", "hint": "Run: python -m mcp_espn_ff.cli authenticate"})
+        else:
+            _out({"error": str(e)})
+        return 1
+
+
+async def cmd_roster(args) -> int:
+    try:
+        league = await _league_service.get_league(args.league_id, args.year)
+        if args.team_id < 1 or args.team_id > len(league.teams):
+            _out({"error": f"team_id must be 1–{len(league.teams)}"})
+            return 1
+        team = league.teams[args.team_id - 1]
+        _out({
+            "team_name": team.team_name,
+            "owner": team.owners,
+            "wins": team.wins,
+            "losses": team.losses,
+            "roster": [
+                {
+                    "name": p.name,
+                    "position": p.position,
+                    "pro_team": p.proTeam,
+                    "points": p.total_points,
+                    "projected_points": p.projected_total_points,
+                }
+                for p in team.roster
+            ],
+        })
+        return 0
+    except Exception as e:
+        if _private_league_hint(e):
+            _out({"error": "private_league", "hint": "Run: python -m mcp_espn_ff.cli authenticate"})
+        else:
+            _out({"error": str(e)})
+        return 1
+
+
+async def cmd_team_info(args) -> int:
+    try:
+        league = await _league_service.get_league(args.league_id, args.year)
+        if args.team_id < 1 or args.team_id > len(league.teams):
+            _out({"error": f"team_id must be 1–{len(league.teams)}"})
+            return 1
+        t = league.teams[args.team_id - 1]
+        _out({
+            "team_name": t.team_name,
+            "owner": t.owners,
+            "wins": t.wins,
+            "losses": t.losses,
+            "ties": t.ties,
+            "points_for": t.points_for,
+            "points_against": t.points_against,
+            "acquisitions": t.acquisitions,
+            "drops": t.drops,
+            "trades": t.trades,
+            "playoff_pct": t.playoff_pct,
+            "final_standing": t.final_standing,
+            "outcomes": t.outcomes,
+        })
+        return 0
+    except Exception as e:
+        if _private_league_hint(e):
+            _out({"error": "private_league", "hint": "Run: python -m mcp_espn_ff.cli authenticate"})
+        else:
+            _out({"error": str(e)})
+        return 1
+
+
+async def cmd_player(args) -> int:
+    try:
+        league = await _league_service.get_league(args.league_id, args.year)
+        found = None
+        for team in league.teams:
+            for p in team.roster:
+                if args.name.lower() in p.name.lower():
+                    found = p
+                    break
+            if found:
+                break
+        if not found:
+            _out({"error": f"Player '{args.name}' not found in league {args.league_id}"})
+            return 1
+        _out({
+            "name": found.name,
+            "position": found.position,
+            "pro_team": found.proTeam,
+            "points": found.total_points,
+            "projected_points": found.projected_total_points,
+            "injured": found.injured,
+            "stats": found.stats,
+        })
+        return 0
+    except Exception as e:
+        if _private_league_hint(e):
+            _out({"error": "private_league", "hint": "Run: python -m mcp_espn_ff.cli authenticate"})
+        else:
+            _out({"error": str(e)})
+        return 1
+
+
+async def cmd_matchups(args) -> int:
+    try:
+        league = await _league_service.get_league(args.league_id, args.year)
+        week = args.week if args.week is not None else league.current_week
+        if week < 1 or week > 17:
+            _out({"error": "week must be 1–17"})
+            return 1
+        matchups = league.box_scores(week)
+        _out([
+            {
+                "home_team": m.home_team.team_name,
+                "home_score": m.home_score,
+                "away_team": m.away_team.team_name if m.away_team else "BYE",
+                "away_score": m.away_score if m.away_team else 0,
+                "winner": (
+                    "HOME" if m.home_score > m.away_score
+                    else "AWAY" if m.away_score > m.home_score
+                    else "TIE"
+                ),
+            }
+            for m in matchups
+        ])
+        return 0
+    except Exception as e:
+        if _private_league_hint(e):
+            _out({"error": "private_league", "hint": "Run: python -m mcp_espn_ff.cli authenticate"})
+        else:
+            _out({"error": str(e)})
+        return 1
+
+
+# ---------------------------------------------------------------------------
+# Argument parser
+# ---------------------------------------------------------------------------
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="python -m mcp_espn_ff.cli",
+        description="ESPN Fantasy Football CLI",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # authenticate
+    sub.add_parser("authenticate", help="Open browser to log in to ESPN and save credentials.")
+
+    # league-info
+    p = sub.add_parser("league-info", help="Show basic league info.")
+    p.add_argument("--league-id", type=int, required=True)
+    p.add_argument("--year", type=int, default=CURRENT_YEAR)
+
+    # standings
+    p = sub.add_parser("standings", help="Show league standings.")
+    p.add_argument("--league-id", type=int, required=True)
+    p.add_argument("--year", type=int, default=CURRENT_YEAR)
+
+    # roster
+    p = sub.add_parser("roster", help="Show a team's roster.")
+    p.add_argument("--league-id", type=int, required=True)
+    p.add_argument("--team-id", type=int, required=True)
+    p.add_argument("--year", type=int, default=CURRENT_YEAR)
+
+    # team-info
+    p = sub.add_parser("team-info", help="Show team season stats.")
+    p.add_argument("--league-id", type=int, required=True)
+    p.add_argument("--team-id", type=int, required=True)
+    p.add_argument("--year", type=int, default=CURRENT_YEAR)
+
+    # player
+    p = sub.add_parser("player", help="Look up a player's stats (fuzzy name search).")
+    p.add_argument("--league-id", type=int, required=True)
+    p.add_argument("--name", required=True)
+    p.add_argument("--year", type=int, default=CURRENT_YEAR)
+
+    # matchups
+    p = sub.add_parser("matchups", help="Show matchups for a week.")
+    p.add_argument("--league-id", type=int, required=True)
+    p.add_argument("--week", type=int, default=None, help="Defaults to current week.")
+    p.add_argument("--year", type=int, default=CURRENT_YEAR)
+
+    return parser
+
+
+COMMANDS = {
+    "authenticate": cmd_authenticate,
+    "league-info": cmd_league_info,
+    "standings": cmd_standings,
+    "roster": cmd_roster,
+    "team-info": cmd_team_info,
+    "player": cmd_player,
+    "matchups": cmd_matchups,
+}
+
+
+def main() -> None:
+    parser = build_parser()
+    args = parser.parse_args()
+    handler = COMMANDS[args.command]
+    exit_code = asyncio.run(handler(args))
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,14 @@
 [project]
-name = "mcp-espn-ff"
-version = "0.1.0"
-description = "Add your description here"
+name = "espn-ff"
+version = "0.2.0"
+description = "ESPN Fantasy Football CLI and Claude Code skills"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
     "espn-api>=0.44.1",
-    "mcp[cli]>=1.5.0",
     "playwright>=1.45.0",
     "python-dotenv>=1.0.1",
 ]
+
+[project.scripts]
+espn-ff = "mcp_espn_ff.cli:main"


### PR DESCRIPTION
I had Claude rewrite this repo as Skills

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces a new CLI surface and repackages the project (renamed distribution + new console script), which could affect how existing users invoke/install the tool. Runtime risk is moderate since it primarily wraps existing service/auth logic but changes execution paths and documentation expectations.
> 
> **Overview**
> Refactors the repo toward a **Claude Code “skills + CLI”** workflow by adding four slash-command skill specs (auth, league, roster/player, and higher-order analysis) under `.claude/commands/`.
> 
> Adds a new `mcp_espn_ff/cli.py` async CLI that exposes subcommands (`authenticate`, `league-info`, `standings`, `roster`, `team-info`, `player`, `matchups`) and standardizes output as pretty-printed JSON with a consistent `private_league` error hint.
> 
> Updates packaging/docs: renames the distribution to `espn-ff`, adds an `espn-ff` console script entrypoint, drops the `mcp[cli]` dependency, and rewrites `README.md` to document the new skills/CLI usage and auth flow.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 745d18a4a8c898b2380dd79b607dcda1b8d9b0dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->